### PR TITLE
Add Diffie-Hellman demo and organize examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# abstract-algebra
+# Abstract Algebra
+
+This repository contains small demonstrations of algebraic concepts.
+See the `demos/` directory for each example and its instructions.

--- a/demos/diffie_hellman/README.md
+++ b/demos/diffie_hellman/README.md
@@ -1,0 +1,9 @@
+# Diffie-Hellman Demo
+
+This demo shows a toy Diffie-Hellman key exchange on the group `(ℤ/pℤ)*` with `p = 23` and generator `g = 5`.
+
+Run the demo:
+
+```bash
+python3 demo.py
+```

--- a/demos/diffie_hellman/demo.py
+++ b/demos/diffie_hellman/demo.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Diffie-Hellman key exchange on a small finite group."""
+
+import random
+import textwrap
+
+
+def main():
+    p, g = 23, 5
+
+    a = random.randint(2, p - 2)
+    A = pow(g, a, p)
+    print(f"Alice → public A = {A}  (g^a mod p)")
+
+    b = random.randint(2, p - 2)
+    B = pow(g, b, p)
+    print(f"Bob   → public B = {B}  (g^b mod p)")
+
+    s_alice = pow(B, a, p)
+    s_bob = pow(A, b, p)
+    assert s_alice == s_bob
+    print(f"\n★ Shared secret = {s_alice}")
+
+    cycle = []
+    x = 1
+    for _ in range(p - 1):
+        cycle.append(x)
+        x = (x * g) % p
+    print("\nPowers of g cover the whole group:")
+    print(textwrap.fill(" ".join(f"{n:2}" for n in cycle), 60))
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/finite_group/README.md
+++ b/demos/finite_group/README.md
@@ -1,0 +1,9 @@
+# Finite Group Demo
+
+This example illustrates the integers modulo `n` under addition as a simple finite group.
+
+Run the demo:
+
+```bash
+python3 demo.py
+```

--- a/demos/finite_group/demo.py
+++ b/demos/finite_group/demo.py
@@ -1,0 +1,43 @@
+"""Finite group demo using integers modulo n.
+
+This script defines the integers modulo n under addition as a finite group.
+"""
+
+from typing import List
+
+class FiniteGroup:
+    def __init__(self, n: int):
+        self.n = n
+        self.elements = list(range(n))
+
+    def operation(self, a: int, b: int) -> int:
+        """Group operation: addition modulo n."""
+        return (a + b) % self.n
+
+    def identity(self) -> int:
+        return 0
+
+    def inverse(self, a: int) -> int:
+        """Return the additive inverse of a modulo n."""
+        return (-a) % self.n
+
+    def table(self) -> List[List[int]]:
+        """Return the Cayley table of the group."""
+        return [[self.operation(a, b) for b in self.elements] for a in self.elements]
+
+
+def demo() -> None:
+    n = 4
+    group = FiniteGroup(n)
+    print(f"Elements: {group.elements}")
+    print(f"Identity: {group.identity()}")
+    for a in group.elements:
+        print(f"Inverse of {a}: {group.inverse(a)}")
+    print("Cayley table:")
+    table = group.table()
+    for row in table:
+        print(" ".join(str(x) for x in row))
+
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
## Summary
- keep the root README short and point to the `demos` folder
- move finite group example to `demos/finite_group/` with its own README
- add a new toy Diffie–Hellman key exchange demo under `demos/diffie_hellman/`

## Testing
- `python3 -m py_compile demos/finite_group/demo.py demos/diffie_hellman/demo.py`
- `python3 demos/finite_group/demo.py`
- `python3 demos/diffie_hellman/demo.py`
